### PR TITLE
Fix RangeError in Random Number Generation

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -9,7 +9,7 @@ class Utils {
   static const double maxAmplitude = 8500;
   static const double maxScale = 1.3;
 
-  static int get randomNumber => _random.nextInt(1 << 32) - (1 << 31);
+  static int get randomNumber => _random.nextInt(1 << 31);
 
   static Shader createShader(
     double x,

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -24,8 +24,8 @@ class Utils {
       // transform: GradientRotation(angle ?? 10 / 10),
       colors: colors ??
           [
-            const Color(0xff2BCEFF).withOpacity(0.3),
-            const Color(0xff0976E3).withOpacity(0.3),
+            const Color(0xff2BCEFF).withValues(alpha: 0.3),
+            const Color(0xff0976E3).withValues(alpha: 0.3),
           ],
     ).createShader(
       Rect.fromCircle(center: Offset(x, y), radius: 50.0),

--- a/lib/wave_drawable.dart
+++ b/lib/wave_drawable.dart
@@ -167,8 +167,8 @@ class WaveDrawable {
       _colors = colors;
     } else {
       _colors = [
-        const Color(0xff2BCEFF).withOpacity(0.3),
-        const Color(0xff0976E3).withOpacity(0.3),
+        const Color(0xff2BCEFF).withValues(alpha: 0.3),
+        const Color(0xff0976E3).withValues(alpha: 0.3),
       ];
     }
   }

--- a/lib/wave_drawable.dart
+++ b/lib/wave_drawable.dart
@@ -176,9 +176,9 @@ class WaveDrawable {
   void _generateBlob(List<double> r, List<double> a, int i) {
     double angleDif = 360 / N * 0.05;
     double radDif = _maxRadius - _minRadius;
-    r[i] = _minRadius + ((Utils.randomNumber % 100) / 100).abs() * radDif;
-    a[i] = 360 / N * i + ((Utils.randomNumber % 100) / 100) * angleDif;
-    _speed[i] = (0.017 + 0.003 * ((Utils.randomNumber % 100).abs() / 100));
+    r[i] = _minRadius + (Utils.randomNumber.abs() % 100 / 100) * radDif;
+    a[i] = 360 / N * i + (Utils.randomNumber.abs() % 100 / 100) * angleDif;
+    _speed[i] = (0.017 + 0.003 * (Utils.randomNumber.abs() % 100 / 100));
   }
 
   void _update(double amplitude, double speedScale) {


### PR DESCRIPTION
# Fix RangeError in Random Number Generation : #3 

## Description  
This PR fixes a `RangeError` that occurred when generating random numbers, which caused crashes in the web build.  

### Changes Made  
1. **Fixed the random number generation issue**  
   - **Before:**  
     ```dart
     static int get randomNumber => _random.nextInt(1 << 32) - (1 << 31);
     ```  
   - **After:**  
     ```dart
     static int get randomNumber => _random.nextInt(1 << 31);
     ```  
   - Ensures that the generated number remains within a valid range.  

2. **Refactored radius and angle calculations**  
   - **Before:**  
     ```dart
     r[i] = _minRadius + ((Utils.randomNumber % 100) / 100).abs() * radDif;
     a[i] = 360 / N * i + ((Utils.randomNumber % 100) / 100) * angleDif;
     _speed[i] = (0.017 + 0.003 * ((Utils.randomNumber % 100).abs() / 100));
     ```  
   - **After:**  
     ```dart
     r[i] = _minRadius + (Utils.randomNumber.abs() % 100 / 100) * radDif;
     a[i] = 360 / N * i + (Utils.randomNumber.abs() % 100 / 100) * angleDif;
     _speed[i] = (0.017 + 0.003 * (Utils.randomNumber.abs() % 100 / 100));
     ```  
   - This improves stability and prevents negative values from affecting calculations.  

### Why This Fix?  
- Ensures `randomNumber` is always within a valid range.  
- Prevents potential negative values from impacting calculations.  
- Improves overall code clarity and stability.  